### PR TITLE
Add API toggle and improve pass cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,6 +46,11 @@
             </div>
             <button type="button" onclick="addResort()">+ Add Resort</button>
 
+            <label class="api-toggle">
+                <input type="checkbox" id="multiApiToggle" checked>
+                Use multi-pass API
+            </label>
+
             <button type="submit" id="submitBtn">Submit</button>
         </form>
 

--- a/results.js
+++ b/results.js
@@ -32,8 +32,24 @@ function sortBy(field) {
   sorted.forEach(pass => {
     const card = document.createElement("div");
     card.className = "pass-card";
+
+    let passesHtml = "";
+    if (Array.isArray(pass.passes) && pass.passes.length > 0) {
+      passesHtml += '<div class="pass-list">';
+      pass.passes.forEach(p => {
+        passesHtml += `
+          <div class="sub-pass">
+            <h3>${p.name}</h3>
+            ${p.cost !== undefined ? `<div class="meta">Cost: $${p.cost}</div>` : ''}
+          </div>`;
+      });
+      passesHtml += '</div>';
+    } else if (pass.name) {
+      passesHtml = `<h2>${pass.name}</h2>`;
+    }
+
     card.innerHTML = `
-      <h2>${pass.name}</h2>
+      ${passesHtml}
       <div class="meta">Total Cost: $${pass.total_cost}</div>
       <div class="meta">Total Days: ${pass.total_days}</div>
       <div class="badge ${pass.blackout_true ? 'blackout' : ''}">

--- a/static/script.js
+++ b/static/script.js
@@ -52,10 +52,18 @@ document.getElementById("expertForm").addEventListener("submit", async function(
     return;
   }
 
-  const response = await fetch("https://pass-picker-expert-mode.onrender.com/expert_mode/calculate", {
+  const useMulti = document.getElementById('multiApiToggle')?.checked;
+  const url = useMulti
+    ? "https://pass-picker-expert-mode.onrender.com/expert_mode/calculate"
+    : "https://pass-picker-expert-mode.onrender.com/score_pass";
+  const payload = useMulti
+    ? { riders, resort_plan: resorts }
+    : { riders, resorts };
+
+  const response = await fetch(url, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ riders, resort_plan: resorts })
+    body: JSON.stringify(payload)
   });
 
   const result = await response.json();

--- a/static/style.css
+++ b/static/style.css
@@ -23,3 +23,9 @@ form {
 button {
     margin-top: 10px;
 }
+
+.api-toggle {
+    display: block;
+    margin-top: 10px;
+    text-align: left;
+}

--- a/style.css
+++ b/style.css
@@ -62,3 +62,19 @@ h1 {
   background-color: #ffdddd;
   color: #b10000;
 }
+
+.pass-list {
+  margin-bottom: 8px;
+}
+
+.sub-pass {
+  border-top: 1px solid #ddd;
+  padding-top: 6px;
+  margin-top: 6px;
+}
+
+.sub-pass:first-child {
+  border-top: none;
+  padding-top: 0;
+  margin-top: 0;
+}


### PR DESCRIPTION
## Summary
- add API selection toggle to index.html
- send requests to single or multi API endpoints based on toggle
- style toggle for consistency
- support multi-pass results in card layout

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_688d04a602e88323abf9fc8020d56e06