### PR TITLE
Fix backend endpoint mappings

### DIFF
--- a/patch_static_script.js
+++ b/patch_static_script.js
@@ -52,11 +52,14 @@ document.getElementById("expertForm").addEventListener("submit", async function(
     return;
   }
 
-  const response = await fetch("https://pass-picker-expert-mode.onrender.com/score_pass", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ riders, resorts })
-  });
+  const response = await fetch(
+    "https://pass-picker-expert-mode.onrender.com/expert_mode/calculate",
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ riders, resort_plan: resorts })
+    }
+  );
 
   const result = await response.json();
   renderCards(result.valid_passes || []);

--- a/static/script.js
+++ b/static/script.js
@@ -54,12 +54,11 @@ document.getElementById("expertForm").addEventListener("submit", async function(
 
   const useMulti = document.getElementById('multiApiToggle')?.checked;
   const url = useMulti
-    ?
-      "https://pass-picker-expert-mode-multi.onrender.com/expert_mode/calculate"
-    : "https://pass-picker-expert-mode.onrender.com/score_pass";
+    ? "https://pass-picker-expert-mode-multi.onrender.com/score_pass"
+    : "https://pass-picker-expert-mode.onrender.com/expert_mode/calculate";
   const payload = useMulti
-    ? { riders, resort_plan: resorts }
-    : { riders, resorts };
+    ? { riders, resorts }
+    : { riders, resort_plan: resorts };
 
   const response = await fetch(url, {
     method: "POST",


### PR DESCRIPTION
## Summary
- Correct multi-pass toggle to call `score_pass` on the multi API and `expert_mode/calculate` on the standard API
- Align single-endpoint script with new `expert_mode/calculate` payload structure

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_6892a37cc68083238fc19c77255abda6