### PR TITLE
Fix incorrect multi-pass API endpoint

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -54,7 +54,7 @@ document.getElementById("expertForm").addEventListener("submit", async function(
 
   const useMulti = document.getElementById('multiApiToggle')?.checked;
   const url = useMulti
-    ? "https://pass-picker-expert-mode-multi.onrender.com/score_pass"
+    ? "https://pass-picker-expert-mode-multi.onrender.com/score_multi_pass"
     : "https://pass-picker-expert-mode.onrender.com/expert_mode/calculate";
   const payload = useMulti
     ? { riders, resorts }


### PR DESCRIPTION
## Summary
- Point multi-pass requests to `/score_multi_pass` so the toggle uses the correct path

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6892abe11eec8323aeb230c943bdfd67