### PR TITLE
Restore original UI while preserving dual API backend support

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,71 +1,71 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Snow Genius — Expert Mode</title>
-    <meta name="description" content="Expert Mode — Multi-pass scorer" />
-    <link rel="preconnect" href="https://pass-picker-expert-mode-multi.onrender.com" />
-    <style>
-      :root { color-scheme: light dark; }
-      body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif; margin: 0; padding: 24px; line-height: 1.45; }
-      .container { max-width: 960px; margin: 0 auto; }
-      .card { border: 1px solid #ccc; border-radius: 12px; padding: 16px; margin: 12px 0; }
-      label { display: block; margin: 8px 0 4px; }
-      input, select, button, textarea { font: inherit; padding: 8px 10px; border-radius: 8px; border: 1px solid #bbb; width: 100%; box-sizing: border-box; }
-      button { cursor: pointer; width: auto; }
-      .row { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
-      .error { color: #b00020; font-weight: 600; white-space: pre-wrap; }
-      pre { background: rgba(127,127,127,0.12); padding: 12px; border-radius: 8px; overflow: auto; }
-      .muted { opacity: 0.8; }
-    </style>
-  </head>
-  <body>
+<head>
+    <meta charset="UTF-8">
+    <title>Snow Genius Expert Mode</title>
+    <link rel="stylesheet" href="static/style.css">
+</head>
+<body>
     <div class="container">
-      <h1>Expert Mode — Multi</h1>
-      <p class="muted">Calls the Multi API with CORS-friendly settings.</p>
+        <img src="static/logo.png" alt="Logo" class="logo">
+        <h1>Snow Genius</h1>
+        <h2>EXPERT MODE</h2>
+        <p>Find the lowest-cost ski pass that meets your exact plan.</p>
 
-      <form id="expertForm"
-            data-api-base="https://pass-picker-expert-mode-multi.onrender.com"
-            class="card">
+        <form id="expertForm">
+            <h3>Riders</h3>
+            <div id="riders">
+                <div class="rider">
+                    <input type="number" placeholder="Age" name="age" required>
+                    <select name="category">
+                        <option value="none">None</option>
+                        <option value="military">Military</option>
+                        <option value="student">Student</option>
+                        <option value="nurse">Nurse</option>
+                    </select>
+                </div>
+            </div>
+            <button type="button" onclick="addRider()">+ Add Rider</button>
 
-        <div class="row">
-          <div>
-            <label>Rider Age</label>
-            <input id="age" type="number" min="0" value="39" required />
-          </div>
-          <div>
-            <label>Category</label>
-            <select id="category">
-              <option value="None" selected>None</option>
-              <option value="Student">Student</option>
-              <option value="Military">Military</option>
-              <option value="Nurse">Nurse</option>
-            </select>
-          </div>
+            <h3>Resorts</h3>
+            <div id="resorts">
+                <div class="resort">
+                    <select name="resort_id" required>
+                        <option value="">-- Select resort --</option>
+                        <option value="loon">Loon</option>
+                        <option value="stratton">Stratton</option>
+                        <option value="sunday_river">Sunday River</option>
+                        <option value="sugarloaf">Sugarloaf</option>
+                        <option value="okemo">Okemo</option>
+                        <option value="killington">Killington</option>
+                        <option value="cannon">Cannon</option>
+                    </select>
+                    <input type="number" placeholder="Days" name="days" required>
+                    <label><input type="checkbox" name="blackout_ok"> Blackout Days</label>
+                </div>
+            </div>
+            <button type="button" onclick="addResort()">+ Add Resort</button>
+
+            <label class="api-toggle">
+                <input type="checkbox" id="multiApiToggle" checked>
+                Use multi-pass API
+            </label>
+
+            <button type="submit" id="submitBtn">Submit</button>
+        </form>
+
+        <div class="sort-bar" style="display:none;" id="sortBar">
+            Sort by:
+            <button type="button" onclick="sortBy('total_cost')">Cost</button>
+            <button type="button" onclick="sortBy('total_days')">Days</button>
+            <button type="button" onclick="sortBy('blackout_true')">Blackout</button>
         </div>
 
-        <div class="row">
-          <div>
-            <label>Resort (id or name)</label>
-            <input id="resort" placeholder="loon" value="loon" />
-          </div>
-          <div>
-            <label>Days</label>
-            <input id="days" type="number" min="1" value="2" required />
-          </div>
-        </div>
-
-        <label><input id="blackout_ok" type="checkbox" /> Allow Blackout</label>
-
-        <p><button type="submit">Submit</button></p>
-      </form>
-
-      <div id="errors" class="error"></div>
-      <h3>Raw Response</h3>
-      <pre id="raw"></pre>
+        <div id="results-container" class="card-grid"></div>
     </div>
 
     <script src="static/script.js"></script>
-  </body>
+    <script src="results.js"></script>
+    <script src="autoResize.js"></script>
+</body>
 </html>

--- a/static/script.js
+++ b/static/script.js
@@ -1,136 +1,88 @@
-(function () {
-  // ---- utilities
-  const $ = (sel) => document.querySelector(sel);
-  const byId = (id) => document.getElementById(id);
-  const raw = byId('raw') || { textContent: "" };
-  const errors = byId('errors') || { textContent: "" };
-  const setRaw = (v) => raw.textContent = typeof v === 'string' ? v : JSON.stringify(v, null, 2);
-  const setError = (m) => { errors.textContent = m || ""; };
+function addRider() {
+  const container = document.getElementById('riders');
+  const rider = document.createElement('div');
+  rider.className = 'rider';
+  rider.innerHTML =
+    '<input type="number" placeholder="Age" name="age" required>' +
+    '<select name="category">' +
+    '<option value="none">None</option>' +
+    '<option value="military">Military</option>' +
+    '<option value="student">Student</option>' +
+    '<option value="nurse">Nurse</option>' +
+    '</select>';
+  container.appendChild(rider);
+}
 
-  // ---- ensure a root
-  let root = byId('sg-expert-multi-root');
-  if (!root) {
-    root = document.createElement('div');
-    root.id = 'sg-expert-multi-root';
-    document.currentScript.parentElement.insertBefore(root, document.currentScript);
+function addResort() {
+  const container = document.getElementById('resorts');
+  const resort = document.createElement('div');
+  resort.className = 'resort';
+  resort.innerHTML =
+    '<select name="resort_id" required>' +
+    '<option value="">-- Select resort --</option>' +
+    '<option value="loon">Loon</option>' +
+    '<option value="stratton">Stratton</option>' +
+    '<option value="sunday_river">Sunday River</option>' +
+    '<option value="sugarloaf">Sugarloaf</option>' +
+    '<option value="okemo">Okemo</option>' +
+    '<option value="killington">Killington</option>' +
+    '<option value="cannon">Cannon</option>' +
+    '</select>' +
+    '<input type="number" placeholder="Days" name="days" required>' +
+    '<label><input type="checkbox" name="blackout_ok"> Blackout Days</label>';
+  container.appendChild(resort);
+}
+
+document.getElementById("expertForm").addEventListener("submit", async function(e) {
+  e.preventDefault();
+
+  const riders = [...document.querySelectorAll("#riders .rider")].map(div => ({
+    age: parseInt(div.querySelector('input[name="age"]').value),
+    category: div.querySelector('select[name="category"]').value
+  }));
+
+  const resorts = [...document.querySelectorAll("#resorts .resort")].map(div => ({
+    resort_id: div.querySelector('select[name="resort_id"]').value,
+    days: parseInt(div.querySelector('input[name="days"]').value),
+    blackout_ok: div.querySelector('input[name="blackout_ok"]').checked
+  }));
+
+  if (riders.length === 0 || resorts.length === 0) {
+    alert("Please add at least one rider and one resort.");
+    return;
   }
 
-  // ---- create form if missing
-  let form = byId('expertForm');
-  if (!form) {
-    form = document.createElement('form');
-    form.id = 'expertForm';
-    form.className = 'card';
-    form.innerHTML = `
-      <div class="row">
-        <div>
-          <label>Rider Age</label>
-          <input id="age" type="number" min="0" value="39" required />
-        </div>
-        <div>
-          <label>Category</label>
-          <select id="category">
-            <option value="None" selected>None</option>
-            <option value="Student">Student</option>
-            <option value="Military">Military</option>
-            <option value="Nurse">Nurse</option>
-          </select>
-        </div>
-      </div>
+  const useMulti = document.getElementById('multiApiToggle')?.checked;
+  const url = useMulti
+    ? "https://pass-picker-expert-mode-multi.onrender.com/score_multi_pass"
+    : "https://pass-picker-expert-mode.onrender.com/score_pass";
+  const payload = useMulti
+    ? {
+        riders,
+        resort_days: resorts.map(r => ({
+          resort: r.resort_id,
+          days: r.days,
+          blackout_ok: r.blackout_ok
+        }))
+      }
+    : { riders, resorts };
 
-      <h3>Resort Plan</h3>
-      <div class="row">
-        <div>
-          <label>Resort</label>
-          <input id="resort" type="text" placeholder="loon" value="loon" />
-        </div>
-        <div>
-          <label>Days</label>
-          <input id="days" type="number" min="1" value="7" />
-        </div>
-        <div style="display:flex;align-items:center;gap:.5rem">
-          <input id="blackout_ok" name="blackout_ok" type="checkbox" />
-          <label for="blackout_ok">Blackout OK</label>
-        </div>
-      </div>
-
-      <div class="row">
-        <div>
-          <label>Mode</label>
-          <select id="apiMode">
-            <option value="multi" selected>Multi</option>
-            <option value="single">Single</option>
-          </select>
-        </div>
-        <div>
-          <label>API Base</label>
-          <input id="apiBase" type="text"
-            value="https://pass-picker-expert-mode-multi.onrender.com" />
-        </div>
-      </div>
-
-      <p><button type="submit">Submit</button></p>
-    `;
-    root.appendChild(form);
-
-    // optional consoles
-    if (!byId('errors')) {
-      const e = document.createElement('div'); e.id = 'errors'; e.className = 'error'; root.appendChild(e);
-    }
-    if (!byId('raw')) {
-      const h = document.createElement('h3'); h.textContent = 'Raw Response'; root.appendChild(h);
-      const p = document.createElement('pre'); p.id = 'raw'; root.appendChild(p);
-    }
-  }
-
-  // ---- helpers
-  async function postJson(url, body) {
-    const r = await fetch(url, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(body),
+  try {
+    const response = await fetch(url, {
+      method: "POST",
+      mode: "cors",
+      credentials: "omit",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload)
     });
-    if (!r.ok) throw new Error(`${r.status} ${r.statusText}`);
-    return r.json();
-  }
 
-  function readUI() {
-    const age = Number(byId('age')?.value ?? 0);
-    const category = byId('category')?.value ?? 'None';
-    const resort = byId('resort')?.value?.trim() || '';
-    const days = Number(byId('days')?.value ?? 0);
-    const blackout_ok = !!byId('blackout_ok')?.checked;
+    const result = await response.json();
 
-    return {
-      riders: [{ age, category }],
-      resort_days: resort && days ? [{ resort, days, blackout_ok }] : []
-    };
-  }
-
-  // ---- submit handler
-  form.addEventListener('submit', async (ev) => {
-    ev.preventDefault();
-    setError('');
-    setRaw('');
-
-    const apiBase = byId('apiBase')?.value?.trim()
-      || 'https://pass-picker-expert-mode-multi.onrender.com';
-    const mode = byId('apiMode')?.value || 'multi';
-    const url = `${apiBase}/${mode === 'multi' ? 'score_multi_pass' : 'score_pass'}`;
-
-    const body = readUI();
-    if (!body.resort_days.length) {
-      setError('Please provide at least one resort and days.');
-      return;
+    if (typeof renderCards === 'function') {
+      renderCards(result.valid_passes || []);
     }
-
-    try {
-      setRaw({ url, body });
-      const json = await postJson(url, body);
-      setRaw(json);
-    } catch (e) {
-      setError('Request failed: ' + (e?.message || String(e)));
-      console.error(e);
-    }
-  });
-})();
+  } catch (err) {
+    console.error(err);
+    alert("Request failed: " + (err?.message || err));
+  }
+});


### PR DESCRIPTION
## Summary
- revert to full multi-pass form with rider/resort inputs and API toggle
- update script to post `resort_days` to `/score_multi_pass` or `resorts` to `/score_pass` using CORS-friendly fetch

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689cc6757e4c8323aa861c1e036ac767