### PR TITLE
Add toggle for multi API and stylized results

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Expert Mode — Multi & Single</title>
-  <link rel="stylesheet" href="static/styles.css" />
+  <link rel="stylesheet" href="static/style.css" />
 </head>
 <body>
   <header class="page-hero">
@@ -15,16 +15,12 @@
   </header>
 
   <main class="container">
-    <!-- Mode + API Bases -->
+    <!-- API Bases -->
     <section class="card">
       <div class="row">
-        <div class="field">
-          <label for="mode">Mode</label>
-          <div class="segmented" role="tablist" aria-label="API Mode">
-            <button id="mode-multi" class="seg active" data-mode="multi" role="tab" aria-selected="true">Multi</button>
-            <button id="mode-single" class="seg" data-mode="single" role="tab" aria-selected="false">Single</button>
-          </div>
-          <input id="mode" type="hidden" value="multi" />
+        <div class="field inline">
+          <input id="useMulti" type="checkbox" />
+          <label for="useMulti">Use Multi API</label>
         </div>
       </div>
 
@@ -83,6 +79,13 @@
       <h2 class="card-title">Result</h2>
       <div id="status" class="status" role="status" aria-live="polite"></div>
 
+      <div id="sortBar" class="sort-bar" style="display:none;">
+        <button type="button" onclick="sortBy('total_cost')">Sort by Cost</button>
+        <button type="button" onclick="sortBy('total_days')">Sort by Days</button>
+        <button type="button" onclick="sortBy('blackout_true')">Sort by Blackouts</button>
+      </div>
+      <div id="results-container" class="card-grid"></div>
+
       <details open>
         <summary>Request</summary>
         <pre id="req" class="codeblock"></pre>
@@ -100,6 +103,7 @@
   </main>
 
   <!-- Auto-height to parent when embedded -->
+  <script defer src="results.js"></script>
   <script defer src="static/script.js?v=20250813-1"></script>
 </body>
 </html>

--- a/static/style.css
+++ b/static/style.css
@@ -70,3 +70,17 @@ h1{margin:0;font-size:28px}
   font-size:12px;
 }
 .footer{color:var(--muted); text-align:center; margin:32px 0 12px}
+
+/* ----- Result cards ----- */
+.sort-bar{margin:20px auto;text-align:center}
+.sort-bar button{margin:0 10px;padding:6px 12px;cursor:pointer}
+.card-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(250px,1fr));gap:20px}
+.pass-card{background:var(--card);border:1px solid var(--border);border-radius:10px;padding:16px;box-shadow:0 2px 6px rgba(0,0,0,0.1);transition:transform .2s}
+.pass-card:hover{transform:scale(1.02)}
+.pass-card h2{margin-top:0;font-size:1.2em}
+.pass-card .meta{margin-top:10px;font-size:.95em}
+.badge{display:inline-block;padding:4px 8px;border-radius:5px;font-size:.75em;background-color:#eee;color:#444;margin-top:8px}
+.badge.blackout{background-color:#ffdddd;color:#b10000}
+.pass-list{margin-bottom:8px}
+.sub-pass{border-top:1px solid #ddd;padding-top:6px;margin-top:6px}
+.sub-pass:first-child{border-top:none;padding-top:0;margin-top:0}


### PR DESCRIPTION
## Summary
- Add "Use Multi API" checkbox to choose between single and multi endpoints
- Render results as sortable cards and support multi-pass combos
- Style card grid and sort bar for better presentation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689cd113e7808323aee62fc66367e14c