### PR TITLE
fix: restore logo and repair typeahead

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
 <body>
   <div class="wrap">
     <header class="hero">
-      <img src="static/logo.svg" alt="Expert Mode" class="logo" />
+      <img src="static/logo.png" alt="Snow Genius" class="logo" />
       <h1>Snow Genius</h1>
       <p class="sub">Expert Mode — find the lowest-cost pass or combo that matches your exact plan.</p>
     </header>

--- a/static/script.js
+++ b/static/script.js
@@ -29,8 +29,8 @@ async function loadResortsIndex() {
     const res = await fetch("static/resorts.json", { cache: "no-store" });
     const list = await res.json();
     state.resortsIndex = list.map(r => ({
-      id: r.id || r.code || r.name,
-      name: r.name,
+      id: r.id || r.code || r.resort_id || r.name || r.resort_name,
+      name: r.name || r.resort_name || r.id || r.resort_id,
       state: r.state || r.region || ""
     }));
   } catch (err) {


### PR DESCRIPTION
## Summary
- point header logo to existing PNG asset to match prior UI
- normalize resort data fields so typeahead suggestions populate correctly

## Testing
- `npm test` *(fails: ENOENT Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c05d97af8083238bc1787b2c5fb030