### PR TITLE
Filter resort typeahead by public_access = YES

### DIFF
--- a/assets/script 2.js
+++ b/assets/script 2.js
@@ -93,12 +93,16 @@ function addResortRow(rr){
 
 // Minimal typeahead using full resorts.json
 let RESORTS = [];
+function hasPublicAccess(row){
+  const rawPublicAccess = row?.public_access ?? row?.publicAccess ?? row?.PublicAccess ?? '';
+  return String(rawPublicAccess).trim().toLowerCase() === 'yes';
+}
 async function loadResorts(){
   try{
     const r = await fetch(RESORTS_URL);
     if(!r.ok) throw new Error(`Failed to load resorts (${r.status})`);
     const data = await r.json();
-    RESORTS = Array.isArray(data) ? data : [];
+    RESORTS = (Array.isArray(data) ? data : []).filter(hasPublicAccess);
   }catch(e){
     console.error('Failed to load resorts.json', e);
   }

--- a/assets/script.js
+++ b/assets/script.js
@@ -399,8 +399,14 @@
     return raw;
   }
 
+  function hasPublicAccess(row) {
+    const rawPublicAccess = row?.public_access ?? row?.publicAccess ?? row?.PublicAccess ?? "";
+    return normalizeText(rawPublicAccess) === "yes";
+  }
+
   function parseResortRows(list) {
     return (Array.isArray(list) ? list : [])
+      .filter((row) => hasPublicAccess(row))
       .map((row) => {
         const rawId = row.resort_id ?? row.id ?? row.ResortID ?? row.ResortId ?? row.slug ?? "";
         const rawName = row.resort_name ?? row.name ?? row.ResortName ?? row.title ?? "";

--- a/static/script.js
+++ b/static/script.js
@@ -84,6 +84,11 @@ document.addEventListener("DOMContentLoaded", () => {
   });
 
   // typeahead logic: requires at least 3 chars
+  function hasPublicAccess(row) {
+    const rawPublicAccess = row?.public_access ?? row?.publicAccess ?? row?.PublicAccess ?? "";
+    return String(rawPublicAccess).trim().toLowerCase() === "yes";
+  }
+
   async function loadResorts() {
     const resp = await fetch("resorts.json", {
       credentials: "same-origin",
@@ -91,7 +96,7 @@ document.addEventListener("DOMContentLoaded", () => {
     });
     if (!resp.ok) throw new Error(`Failed to load resorts (${resp.status})`);
     const data = await resp.json();
-    return Array.isArray(data) ? data : [];
+    return (Array.isArray(data) ? data : []).filter(hasPublicAccess);
   }
   let resortsData = [];
   loadResorts().then(d => { resortsData = d; }).catch(err => {


### PR DESCRIPTION
## Summary
- filter resort catalogs used by typeahead to only include rows where `public_access` resolves to `yes`
- apply the filter in the primary app script and legacy/static script variants for consistency

## Validation
- verified local dataset counts show filtering behavior (546 total rows, 468 with public_access=yes)