### PR TITLE
[codex] Fix share link clipboard fallback

### DIFF
--- a/assets/script.js
+++ b/assets/script.js
@@ -1027,20 +1027,76 @@
       return;
     }
 
+    let copied = false;
     if (navigator.clipboard?.writeText) {
-      await navigator.clipboard.writeText(url);
-    } else {
-      const textarea = document.createElement("textarea");
-      textarea.value = url;
-      textarea.setAttribute("readonly", "");
-      textarea.style.position = "fixed";
-      textarea.style.left = "-9999px";
-      document.body.appendChild(textarea);
-      textarea.select();
-      document.execCommand("copy");
+      try {
+        await navigator.clipboard.writeText(url);
+        copied = true;
+      } catch (_error) {
+        copied = false;
+      }
+    }
+
+    if (!copied) {
+      copied = copyTextWithSelection(url);
+    }
+
+    if (!copied) {
+      showShareLinkFallback(url);
+      setStatus("Share link ready. Select and copy it from the field.");
+      return;
+    }
+
+    setStatus("Share link copied.");
+  }
+
+  function copyTextWithSelection(text) {
+    const textarea = document.createElement("textarea");
+    textarea.value = text;
+    textarea.setAttribute("readonly", "");
+    textarea.style.position = "fixed";
+    textarea.style.left = "-9999px";
+    textarea.style.top = "0";
+    document.body.appendChild(textarea);
+    textarea.focus();
+    textarea.select();
+
+    let copied = false;
+    try {
+      copied = document.execCommand("copy");
+    } catch (_error) {
+      copied = false;
+    } finally {
       textarea.remove();
     }
-    setStatus("Share link copied.");
+
+    return copied;
+  }
+
+  function showShareLinkFallback(url) {
+    if (!els.formError) return;
+    els.formError.hidden = false;
+    els.formError.replaceChildren();
+
+    const message = document.createElement("div");
+    message.textContent = "Copy blocked by this page's permissions policy. Select the link below to copy it manually.";
+
+    const input = document.createElement("input");
+    input.className = "input share-link-fallback";
+    input.type = "text";
+    input.value = url;
+    input.setAttribute("readonly", "");
+    input.setAttribute("aria-label", "Share link");
+    input.addEventListener("focus", () => input.select());
+    input.addEventListener("click", () => input.select());
+
+    els.formError.appendChild(message);
+    els.formError.appendChild(input);
+    window.requestAnimationFrame(() => {
+      input.focus();
+      input.select();
+      queueHeightPost();
+    });
   }
 
   function initializeSharedItinerary() {

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -498,6 +498,11 @@ body{
   color:var(--danger);
 }
 
+.share-link-fallback{
+  margin-top:8px;
+  color:var(--ink);
+}
+
 .visually-hidden{
   position:absolute!important;
   height:1px;


### PR DESCRIPTION
## Summary
- Catches Permissions Policy failures from `navigator.clipboard.writeText()` instead of surfacing the browser exception.
- Falls back to selection-based copying when the Clipboard API is unavailable or blocked.
- Shows a focused manual share-link field when all programmatic copy paths are blocked.

## Validation
- `node --check assets/script.js`
- `git diff --check`
- Local headless Chrome smoke forcing `navigator.clipboard.writeText()` to throw and `document.execCommand('copy')` to fail, verifying the manual share-link fallback appears with encoded `sg` and `run=1` params.