### PR TITLE
Fix shared itinerary landing state

### DIFF
--- a/assets/script.js
+++ b/assets/script.js
@@ -172,6 +172,7 @@
     rawRequest: document.querySelector("#raw-request"),
     rawResponse: document.querySelector("#raw-response"),
     results: document.querySelector("#results"),
+    formNotice: document.querySelector("#form-notice"),
     formError: document.querySelector("#form-error"),
     formStatus: document.querySelector("#form-status"),
   };
@@ -222,6 +223,16 @@
     if (!els.results) return;
     const reduceMotion = Boolean(window.matchMedia?.("(prefers-reduced-motion: reduce)").matches);
     const targetTop = Math.max(0, window.scrollY + els.results.getBoundingClientRect().top - 18);
+    window.scrollTo({
+      top: targetTop,
+      behavior: reduceMotion ? "auto" : "smooth",
+    });
+  }
+
+  function scrollToPlanner() {
+    if (!els.appMain) return;
+    const reduceMotion = Boolean(window.matchMedia?.("(prefers-reduced-motion: reduce)").matches);
+    const targetTop = Math.max(0, window.scrollY + els.appMain.getBoundingClientRect().top - 18);
     window.scrollTo({
       top: targetTop,
       behavior: reduceMotion ? "auto" : "smooth",
@@ -379,6 +390,19 @@
     }
     els.formError.hidden = false;
     els.formError.textContent = message;
+    queueHeightPost();
+  }
+
+  function showNotice(message) {
+    if (!els.formNotice) return;
+    if (!message) {
+      els.formNotice.hidden = true;
+      els.formNotice.textContent = "";
+      queueHeightPost();
+      return;
+    }
+    els.formNotice.hidden = false;
+    els.formNotice.textContent = message;
     queueHeightPost();
   }
 
@@ -746,6 +770,7 @@
     els.resortsWrap.appendChild(createResortRow());
     els.rawRequest.textContent = "{}";
     els.rawResponse.textContent = "{}";
+    showNotice("");
     showError("");
     clearResults();
     clearShareParamsFromUrl();
@@ -948,7 +973,7 @@
     }
     const url = new URL(window.location.href);
     url.searchParams.set(SHARE_STATE_PARAM, encodeShareState(collectShareState()));
-    url.searchParams.set(SHARE_AUTO_RUN_PARAM, "1");
+    url.searchParams.delete(SHARE_AUTO_RUN_PARAM);
     url.hash = "";
     return url.toString();
   }
@@ -966,10 +991,11 @@
     }
   }
 
-  function applyShareState(state) {
+  function applyShareState(state, options = {}) {
     if (!state || typeof state !== "object") {
       throw new Error("Shared itinerary format is invalid.");
     }
+    const shouldAutoRun = Boolean(options.autoRun);
 
     const riders = Array.isArray(state.riders) ? state.riders.slice(0, MAX_RIDERS) : [];
     const resorts = Array.isArray(state.resorts) ? state.resorts.slice(0, MAX_RESORTS) : [];
@@ -1011,12 +1037,18 @@
     els.rawRequest.textContent = "{}";
     els.rawResponse.textContent = "{}";
     showError("");
+    showNotice(
+      shouldAutoRun
+        ? "Shared itinerary loaded. Running recommendations now..."
+        : "Shared itinerary loaded. Review the trip and press Submit to see recommendations."
+    );
     clearResults();
     setStatus("Shared itinerary loaded.");
     queueHeightPost();
   }
 
   async function copyShareLink() {
+    showNotice("");
     showError("");
     let url;
     try {
@@ -1115,9 +1147,10 @@
     if (!shared) return;
 
     try {
-      applyShareState(shared.state);
+      applyShareState(shared.state, { autoRun: shared.autoRun });
+      window.requestAnimationFrame(scrollToPlanner);
       if (shared.autoRun) {
-        submitRequest().catch((error) => {
+        submitRequest({ fromSharedLink: true }).catch((error) => {
           showError(error instanceof Error ? error.message : "Shared itinerary failed to run.");
           setStatus("Shared itinerary failed to run.");
         });
@@ -1724,8 +1757,12 @@
     revealResults();
   }
 
-  async function submitRequest() {
+  async function submitRequest(options = {}) {
+    const fromSharedLink = Boolean(options.fromSharedLink);
     showError("");
+    if (!fromSharedLink) {
+      showNotice("");
+    }
     setStatus("");
 
     const { payload, errors } = buildRequest();
@@ -1736,6 +1773,10 @@
       showError(errors[0]);
       clearResults();
       setStatus("Validation failed.");
+      if (fromSharedLink) {
+        showNotice("Shared itinerary loaded, but it needs a valid trip before recommendations can run.");
+        scrollToPlanner();
+      }
       return;
     }
 
@@ -1774,6 +1815,7 @@
       }
 
       renderResults(data, payload);
+      showNotice("");
       setStatus("Results updated.");
       scrollToResults();
     } catch (error) {
@@ -1788,7 +1830,11 @@
         els.rawResponse.textContent = JSON.stringify({ error: message }, null, 2);
       }
       clearResults();
-      setStatus("Request failed.");
+      if (fromSharedLink) {
+        showNotice("Shared itinerary loaded, but recommendations could not run automatically. Press Submit to try again.");
+        scrollToPlanner();
+      }
+      setStatus(fromSharedLink ? "Shared itinerary loaded. Automatic recommendations failed." : "Request failed.");
     } finally {
       if (timeoutId !== null) {
         window.clearTimeout(timeoutId);
@@ -1807,6 +1853,7 @@
         return;
       }
       showError("");
+      showNotice("");
       els.ridersWrap.appendChild(createRiderRow());
     });
 
@@ -1818,6 +1865,7 @@
         return;
       }
       showError("");
+      showNotice("");
       els.resortsWrap.appendChild(createResortRow());
     });
 
@@ -1828,7 +1876,7 @@
         setStatus("Share link failed.");
       });
     });
-    els.submit?.addEventListener("click", submitRequest);
+    els.submit?.addEventListener("click", () => submitRequest());
   }
 
   initializeExistingRows();

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -489,6 +489,15 @@ body{
   transform:translateY(0);
 }
 
+.notice-banner{
+  margin:10px 0;
+  padding:10px 12px;
+  border:1px solid rgba(10,132,255,.22);
+  border-radius:14px;
+  background:rgba(10,132,255,.08);
+  color:var(--ink);
+}
+
 .error-banner{
   margin:10px 0;
   padding:10px 12px;

--- a/index.html
+++ b/index.html
@@ -73,6 +73,7 @@
       </div>
     </section>
 
+    <div id="form-notice" class="notice-banner" role="status" hidden></div>
     <div id="form-error" class="error-banner" role="alert" hidden></div>
     <div id="form-status" class="visually-hidden" aria-live="polite"></div>
 


### PR DESCRIPTION
## Summary
- stop newly copied shared itinerary links from forcing automatic recommendation runs
- show a visible shared-itinerary notice after URL restore
- scroll restored shared links to the planner and preserve legacy run=1 behavior with visible retry feedback

## Verification
- node --check assets/script.js
- git diff --check
- local browser smoke: restored non-run share URL hydrates rider/resort/day data and shows the notice
- local browser smoke: legacy run=1 URL still attempts auto-run and shows visible retry feedback when fetch fails
- mobile viewport DOM check for restored share URL