### PR TITLE
Auto-run shared itinerary recommendations

### DIFF
--- a/assets/script.js
+++ b/assets/script.js
@@ -960,9 +960,10 @@
     const params = new URLSearchParams(window.location.search || "");
     const encoded = params.get(SHARE_STATE_PARAM);
     if (!encoded) return null;
+    const runMode = String(params.get(SHARE_AUTO_RUN_PARAM) || "").toLowerCase();
     return {
       state: decodeShareState(encoded),
-      autoRun: params.get(SHARE_AUTO_RUN_PARAM) === "1",
+      autoRun: runMode !== "0" && runMode !== "false",
     };
   }
 
@@ -973,7 +974,7 @@
     }
     const url = new URL(window.location.href);
     url.searchParams.set(SHARE_STATE_PARAM, encodeShareState(collectShareState()));
-    url.searchParams.delete(SHARE_AUTO_RUN_PARAM);
+    url.searchParams.set(SHARE_AUTO_RUN_PARAM, "1");
     url.hash = "";
     return url.toString();
   }


### PR DESCRIPTION
## Summary
- auto-submit shared itinerary URLs by default when sg is present
- keep run=0 / run=false as an escape hatch for loading without submit
- emit run=1 on newly generated shared links so the URL behavior is explicit

## Verification
- node --check assets/script.js
- git diff --check
- local browser smoke: shared URL without run=1 restored itinerary and populated raw request on page load
- local browser smoke: run=0 restored itinerary without submitting