### PR TITLE
Remove UI recommendation mode selector

### DIFF
--- a/assets/script.js
+++ b/assets/script.js
@@ -145,7 +145,6 @@
   const SHARE_STATE_VERSION = 1;
   const SHARE_COPY_FEEDBACK_MS = 2200;
   const TOP_COMPARISON_LIMIT = 3;
-  const VALID_RECOMMENDATION_MODES = new Set(["auto", "single", "multi", "closest"]);
   const VALID_RIDER_CATEGORIES = new Set(["military", "student", "first_responder", "medical", "uphill"]);
   const isDevMode = (() => {
     if (typeof window.__SNOW_GENIUS_DEV_MODE__ === "boolean") {
@@ -175,7 +174,6 @@
     clear: document.querySelector("#clear"),
     share: document.querySelector("#share"),
     submit: document.querySelector("#submit"),
-    recommendationMode: document.querySelector("#recommendation-mode"),
     rawRequest: document.querySelector("#raw-request"),
     rawResponse: document.querySelector("#raw-response"),
     results: document.querySelector("#results"),
@@ -966,9 +964,6 @@
     els.resortsWrap.replaceChildren();
     els.ridersWrap.appendChild(createRiderRow());
     els.resortsWrap.appendChild(createResortRow());
-    if (els.recommendationMode) {
-      els.recommendationMode.value = "auto";
-    }
     els.rawRequest.textContent = "{}";
     els.rawResponse.textContent = "{}";
     showNotice("");
@@ -976,11 +971,6 @@
     clearResults();
     clearShareParamsFromUrl();
     setStatus("Form cleared.");
-  }
-
-  function getRecommendationMode() {
-    const mode = String(els.recommendationMode?.value || "auto").trim().toLowerCase();
-    return VALID_RECOMMENDATION_MODES.has(mode) ? mode : "auto";
   }
 
   function buildRequest() {
@@ -1078,7 +1068,6 @@
       payload: {
         riders,
         resorts,
-        mode: getRecommendationMode(),
       },
       errors,
     };
@@ -1136,7 +1125,6 @@
 
     return {
       version: SHARE_STATE_VERSION,
-      mode: getRecommendationMode(),
       riders,
       resorts,
     };
@@ -1207,10 +1195,6 @@
 
     const riders = Array.isArray(state.riders) ? state.riders.slice(0, MAX_RIDERS) : [];
     const resorts = Array.isArray(state.resorts) ? state.resorts.slice(0, MAX_RESORTS) : [];
-    const mode = String(state.mode || "auto").trim().toLowerCase();
-    if (els.recommendationMode) {
-      els.recommendationMode.value = VALID_RECOMMENDATION_MODES.has(mode) ? mode : "auto";
-    }
 
     els.ridersWrap.replaceChildren();
     (riders.length ? riders : [{}]).forEach((rider) => {

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -439,22 +439,6 @@ body{
   border-top:1px solid rgba(23,52,89,.06);
 }
 
-.mode-picker{
-  display:flex;
-  align-items:center;
-  gap:8px;
-  margin-right:auto;
-  color:var(--muted);
-  font-size:13px;
-  font-weight:600;
-}
-
-.mode-picker .select{
-  flex:0 0 168px;
-  padding-top:9px;
-  padding-bottom:9px;
-}
-
 .footer{
   max-width:1040px;
   margin:8px auto 34px;
@@ -965,13 +949,6 @@ body{
   .resort-submit-row{
     flex-wrap:wrap;
     justify-content:stretch;
-  }
-  .mode-picker{
-    flex:1 1 100%;
-    margin-right:0;
-  }
-  .mode-picker .select{
-    flex:1 1 auto;
   }
   .resort-submit-row .btn{
     flex:1 1 auto;

--- a/index.html
+++ b/index.html
@@ -68,15 +68,6 @@
       </div>
 
       <div class="resort-submit-row">
-        <label class="mode-picker">
-          <span>Recommendation Mode</span>
-          <select id="recommendation-mode" class="select" aria-label="Recommendation mode">
-            <option value="auto">Auto</option>
-            <option value="single">Single only</option>
-            <option value="multi">Multi-pass only</option>
-            <option value="closest">Closest only</option>
-          </select>
-        </label>
         <button id="clear" class="btn subtle">Clear</button>
         <button id="share" class="btn subtle" type="button">Share Link</button>
         <button id="submit" class="btn primary">Submit</button>


### PR DESCRIPTION
## Summary
- remove the user-facing recommendation mode selector
- stop sending mode in score requests
- stop storing mode in shared itinerary URLs

## Validation
- node --check assets/script.js
- node JSON parse of resorts.json
- static diff review

Note: Browser runtime was unavailable in this request, so no in-app browser smoke was possible.