### PR TITLE
[codex] Display resort names and submit canonical keys

### DIFF
--- a/assets/script.js
+++ b/assets/script.js
@@ -776,6 +776,17 @@
     return resortByNormalizedName.get(normalized) || null;
   }
 
+  function resortDisplayLabel(value) {
+    const raw = cleanShortText(value || "", MAX_RESORT_INPUT_LENGTH);
+    if (!raw) return "resort";
+    const resort = resortById.get(raw) || resortByNormalizedName.get(normalizeText(raw));
+    if (resort) return resort.label;
+    return raw
+      .replace(/[_-]+/g, " ")
+      .replace(/\s+/g, " ")
+      .replace(/\b\w/g, (character) => character.toUpperCase());
+  }
+
   function wireResortRow(row) {
     const input = row.querySelector(".resort-input");
     const list = row.querySelector(".suggestions");
@@ -1049,7 +1060,6 @@
         totalRequestedDays += days;
         resorts.push({
           id: selectedResort.id,
-          name: selectedResort.name,
           days,
           no_weekends: Boolean(row.querySelector(".no-weekends")?.checked),
           no_blackouts: Boolean(row.querySelector(".no-blackouts")?.checked),
@@ -1622,11 +1632,13 @@
 
     const list = document.createElement("ul");
     list.className = "unmet-list";
-    deficitKeys.sort().forEach((key) => {
-      const li = document.createElement("li");
-      li.textContent = `${key}: ${unmet[key]} day(s) still uncovered`;
-      list.appendChild(li);
-    });
+    deficitKeys
+      .sort((a, b) => resortDisplayLabel(a).localeCompare(resortDisplayLabel(b)))
+      .forEach((key) => {
+        const li = document.createElement("li");
+        li.textContent = `${resortDisplayLabel(key)}: ${unmet[key]} day(s) still uncovered`;
+        list.appendChild(li);
+      });
     container.appendChild(list);
     return container;
   }
@@ -1869,7 +1881,7 @@
         const requested = Number(row.requested_days) || 0;
         const covered = Number(row.covered_days) || 0;
         const uncovered = Math.max(0, Number(row.uncovered_days) || requested - covered);
-        li.textContent = `${riderLabel} at ${row.resort_id || "resort"}: ${covered}/${requested} day(s) covered${uncovered ? `, ${uncovered} uncovered` : ""}.`;
+        li.textContent = `${riderLabel} at ${resortDisplayLabel(row.resort_id)}: ${covered}/${requested} day(s) covered${uncovered ? `, ${uncovered} uncovered` : ""}.`;
         list.appendChild(li);
       });
     details.appendChild(list);

--- a/index.html
+++ b/index.html
@@ -105,6 +105,6 @@
 
   <footer class="footer">© Snow Genius</footer>
 
-  <script src="assets/script.js?v=20260513a" defer></script>
+  <script src="assets/script.js?v=20260611a" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## What changed
- submit canonical resort IDs without duplicating display names in the `/score_pass` request
- translate coverage and unmet resort IDs back to catalog labels in user-facing results
- bump the script cache key so deployed browsers load the fix

## Why
The API returns canonical resort keys for coverage calculations, and the UI was exposing those keys directly. Resort names now remain a presentation concern while backend traffic uses the canonical identifier.

## Validation
- `node --check assets/script.js`
- `git diff --check`
- browser request verification confirmed `id: "killington"` with no `name` field
- mocked API response confirmed both coverage surfaces render `Killington, V.T.` instead of `killington`
- responsive overflow checks passed at 390px and 1280px