### PR TITLE
[codex] Fix result links and add constraint tooltips

### DIFF
--- a/assets/script.js
+++ b/assets/script.js
@@ -998,8 +998,24 @@
         <span class="field-label">Days</span>
         <input type="number" min="1" max="${MAX_DAYS_PER_RESORT}" inputmode="numeric" class="input days-input" placeholder="Days" aria-label="Days requested" />
       </label>
-      <label class="chk"><input type="checkbox" class="no-weekends" /> Only Weekdays</label>
-      <label class="chk"><input type="checkbox" class="no-blackouts" /> No blackout dates</label>
+      <div class="constraint-control">
+        <label class="chk"><input type="checkbox" class="no-weekends" /> Only Weekdays</label>
+        <button
+          type="button"
+          class="tooltip-trigger"
+          aria-label="About Only Weekdays: Use this when you will ski this resort only Monday through Friday. Recommendations may include passes that are not valid on Saturdays or Sundays."
+        >?</button>
+        <span class="tooltip-content" role="tooltip">Use this when you will ski this resort only Monday through Friday. Recommendations may include passes that are not valid on Saturdays or Sundays.</span>
+      </div>
+      <div class="constraint-control">
+        <label class="chk"><input type="checkbox" class="no-blackouts" /> No blackout dates</label>
+        <button
+          type="button"
+          class="tooltip-trigger"
+          aria-label="About No blackout dates: Blackout dates are excluded dates, often holidays, when a pass cannot be used. Select this to show only options without blackout dates."
+        >?</button>
+        <span class="tooltip-content" role="tooltip">Blackout dates are excluded dates, often holidays, when a pass cannot be used. Select this to show only options without blackout dates.</span>
+      </div>
       <button type="button" class="btn subtle remove-resort">Remove resort</button>
     `;
     wireResortRow(row);
@@ -2340,12 +2356,38 @@
     results.slice(0, TOP_COMPARISON_LIMIT).forEach((result, index) => {
       const card = document.createElement("a");
       card.className = "comparison-card";
-      card.href = `#recommendation-option-${index + 1}`;
-      card.addEventListener("click", () => {
-        const target = document.querySelector(card.getAttribute("href"));
+      const targetId = `recommendation-option-${index + 1}`;
+      card.href = `#${targetId}`;
+      card.setAttribute("aria-controls", targetId);
+      card.addEventListener("click", (event) => {
+        if (
+          event.defaultPrevented ||
+          event.button !== 0 ||
+          event.metaKey ||
+          event.ctrlKey ||
+          event.shiftKey ||
+          event.altKey
+        ) {
+          return;
+        }
+
+        const target = document.getElementById(targetId);
+        if (!target) return;
+
+        event.preventDefault();
         if (target instanceof HTMLDetailsElement) {
           target.open = true;
         }
+
+        if (window.history?.pushState && window.location.hash !== card.hash) {
+          window.history.pushState(null, "", card.hash);
+        }
+
+        const reduceMotion = Boolean(window.matchMedia?.("(prefers-reduced-motion: reduce)").matches);
+        target.scrollIntoView({
+          behavior: reduceMotion ? "auto" : "smooth",
+          block: "start",
+        });
       });
       if (index === 0) {
         card.classList.add("best");

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -408,6 +408,75 @@ body{
 
 .chk input{accent-color:var(--brand-blue)}
 
+.constraint-control{
+  position:relative;
+  display:flex;
+  align-items:center;
+  flex:0 0 auto;
+  min-width:0;
+}
+
+.constraint-control .chk{
+  padding-right:35px;
+}
+
+.tooltip-trigger{
+  position:absolute;
+  right:8px;
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  width:22px;
+  height:22px;
+  padding:0;
+  border:1px solid rgba(10,132,255,.26);
+  border-radius:999px;
+  background:rgba(10,132,255,.08);
+  color:#145ca8;
+  font-family:inherit;
+  font-size:12px;
+  font-weight:700;
+  line-height:1;
+  cursor:help;
+}
+
+.tooltip-trigger:hover,
+.tooltip-trigger:focus-visible{
+  border-color:rgba(10,132,255,.48);
+  background:rgba(10,132,255,.14);
+}
+
+.tooltip-trigger:focus-visible{
+  outline:2px solid rgba(10,132,255,.5);
+  outline-offset:2px;
+}
+
+.tooltip-content{
+  position:absolute;
+  z-index:30;
+  left:50%;
+  bottom:calc(100% + 8px);
+  width:min(280px, calc(100vw - 32px));
+  padding:9px 11px;
+  border:1px solid rgba(23,52,89,.14);
+  border-radius:12px;
+  background:rgba(13,27,42,.96);
+  color:#fff;
+  box-shadow:var(--shadow-md);
+  font-size:12px;
+  line-height:1.4;
+  opacity:0;
+  pointer-events:none;
+  transform:translate(-50%, 4px);
+  transition:opacity .15s ease, transform .15s ease;
+}
+
+.constraint-control:hover .tooltip-content,
+.constraint-control:focus-within .tooltip-content{
+  opacity:1;
+  transform:translate(-50%, 0);
+}
+
 .btn{
   display:inline-flex;
   align-items:center;
@@ -720,6 +789,11 @@ body{
 
 .result-card{
   scroll-margin-top:18px;
+}
+
+.result-card:target{
+  border-color:rgba(10,132,255,.34);
+  box-shadow:0 10px 24px rgba(10,132,255,.12);
 }
 
 .alternative-result{
@@ -1063,6 +1137,12 @@ body{
   .days-field{flex:1 1 100%}
   .input, .select{flex:1 1 100%; font-size:16px}
   .chk{white-space:normal}
+  .constraint-control{
+    flex:1 1 100%;
+  }
+  .constraint-control .chk{
+    width:100%;
+  }
   .resort-submit-row{
     flex-wrap:wrap;
     justify-content:stretch;

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
   <title>Snow Genius — Expert Mode</title>
   <link rel="preload" href="resorts.json" as="fetch" crossorigin="anonymous">
   <script src="assets/bootstrap.js?v=20260226a"></script>
-  <link rel="stylesheet" href="assets/styles.css?v=20260617a" />
+  <link rel="stylesheet" href="assets/styles.css?v=20260620a" />
 </head>
 <body>
   <header class="hero hero-compact">
@@ -71,8 +71,24 @@
             <span class="field-label">Days</span>
             <input type="number" min="1" max="60" inputmode="numeric" class="input days-input" placeholder="Days" aria-label="Days requested" />
           </label>
-          <label class="chk"><input type="checkbox" class="no-weekends" /> Only Weekdays</label>
-          <label class="chk"><input type="checkbox" class="no-blackouts" /> No blackout dates</label>
+          <div class="constraint-control">
+            <label class="chk"><input type="checkbox" class="no-weekends" /> Only Weekdays</label>
+            <button
+              type="button"
+              class="tooltip-trigger"
+              aria-label="About Only Weekdays: Use this when you will ski this resort only Monday through Friday. Recommendations may include passes that are not valid on Saturdays or Sundays."
+            >?</button>
+            <span class="tooltip-content" role="tooltip">Use this when you will ski this resort only Monday through Friday. Recommendations may include passes that are not valid on Saturdays or Sundays.</span>
+          </div>
+          <div class="constraint-control">
+            <label class="chk"><input type="checkbox" class="no-blackouts" /> No blackout dates</label>
+            <button
+              type="button"
+              class="tooltip-trigger"
+              aria-label="About No blackout dates: Blackout dates are excluded dates, often holidays, when a pass cannot be used. Select this to show only options without blackout dates."
+            >?</button>
+            <span class="tooltip-content" role="tooltip">Blackout dates are excluded dates, often holidays, when a pass cannot be used. Select this to show only options without blackout dates.</span>
+          </div>
           <button type="button" class="btn subtle remove-resort">Remove resort</button>
         </div>
       </div>
@@ -115,6 +131,6 @@
 
   <footer class="footer">© Snow Genius</footer>
 
-  <script src="assets/script.js?v=20260617a" defer></script>
+  <script src="assets/script.js?v=20260620a" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- open collapsed alternative result details before scrolling to their anchor target
- add accessible help tooltips for weekday-only and blackout-free constraints
- keep the tooltip layout responsive and cache-bust updated assets

## Root cause
The comparison links relied on native hash navigation while their destination content could still be collapsed, so layout changes could leave the requested result outside the viewport.

## Validation
- `node --check assets/script.js`
- `git diff --check`
- representative live request using Loon for three days
- desktop and 390px mobile browser checks for both alternative anchors, tooltip focus behavior, dynamic resort rows, and horizontal overflow