### PR TITLE
Add Expert Mode feedback capture

### DIFF
--- a/assets/script.js
+++ b/assets/script.js
@@ -1,5 +1,7 @@
 (() => {
   const DEFAULT_API_URL = "https://pass-picker-expert-mode-multi.onrender.com/score_pass";
+  const FEEDBACK_ENDPOINT = "PASTE_GOOGLE_APPS_SCRIPT_WEB_APP_URL_HERE";
+  const SOLVER_VERSION = "expert-mode-v1";
   const ALLOWED_REMOTE_API_HOSTS = new Set(["pass-picker-expert-mode-multi.onrender.com"]);
   const PASS_FAMILY_ICON_CONFIG = [
     {
@@ -259,8 +261,27 @@
   let typeaheadCounter = 0;
   let sharedItineraryHandled = false;
   let lastSubmittedPayload = null;
+  let lastExpertModeInput = null;
+  let lastExpertModeOutput = null;
+  let feedbackSessionId = createUniqueId();
+  let feedbackSubmitted = false;
   let shareFeedbackTimeoutId = 0;
   let inMemoryTrackingSessionId = "";
+
+  function createUniqueId() {
+    if (typeof window.crypto?.randomUUID === "function") {
+      return window.crypto.randomUUID();
+    }
+    if (typeof window.crypto?.getRandomValues === "function") {
+      const bytes = new Uint8Array(16);
+      window.crypto.getRandomValues(bytes);
+      bytes[6] = (bytes[6] & 0x0f) | 0x40;
+      bytes[8] = (bytes[8] & 0x3f) | 0x80;
+      const hex = Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0"));
+      return `${hex.slice(0, 4).join("")}-${hex.slice(4, 6).join("")}-${hex.slice(6, 8).join("")}-${hex.slice(8, 10).join("")}-${hex.slice(10).join("")}`;
+    }
+    return `sg-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  }
 
   function postHeight() {
     const body = document.body;
@@ -791,6 +812,13 @@
     queueHeightPost();
   }
 
+  function resetFeedbackCapture() {
+    lastExpertModeInput = null;
+    lastExpertModeOutput = null;
+    feedbackSessionId = createUniqueId();
+    feedbackSubmitted = false;
+  }
+
   function setBusy(isBusy) {
     if (els.submit) {
       els.submit.disabled = isBusy;
@@ -1292,6 +1320,7 @@
 
   function resetForm() {
     resetShareButtonFeedback();
+    resetFeedbackCapture();
     els.ridersWrap.replaceChildren();
     els.resortsWrap.replaceChildren();
     els.ridersWrap.appendChild(createRiderRow());
@@ -2512,7 +2541,170 @@
       els.results.appendChild(card);
     });
 
+    renderFeedbackBox();
     revealResults();
+  }
+
+  function extractRecommendedPasses(output) {
+    if (!output || typeof output !== "object") return [];
+    if (Array.isArray(output.recommended_passes)) return output.recommended_passes;
+    if (Array.isArray(output.passes)) return output.passes;
+    if (Array.isArray(output.selected_passes)) return output.selected_passes;
+    if (output.recommendation) return [output.recommendation];
+    if (output.best_option) return [output.best_option];
+
+    const firstResult = Array.isArray(output.results) ? output.results[0] : null;
+    if (Array.isArray(firstResult?.passes)) return firstResult.passes;
+    if (firstResult) return [firstResult];
+
+    if (Array.isArray(output.ranked_passes)) return output.ranked_passes;
+    return [];
+  }
+
+  function configuredFeedbackEndpoint() {
+    const devEndpoint = isDevMode
+      ? new URLSearchParams(window.location.search || "").get("feedbackEndpoint") || ""
+      : "";
+    const runtimeEndpoint = typeof window.SNOW_GENIUS_FEEDBACK_ENDPOINT === "string"
+      ? window.SNOW_GENIUS_FEEDBACK_ENDPOINT
+      : "";
+    const candidate = (runtimeEndpoint || devEndpoint || FEEDBACK_ENDPOINT).trim();
+    if (!candidate || candidate === "PASTE_GOOGLE_APPS_SCRIPT_WEB_APP_URL_HERE") {
+      throw new Error("Feedback endpoint is not configured.");
+    }
+
+    const endpoint = new URL(candidate);
+    const isGoogleAppsScript = (
+      endpoint.protocol === "https:" &&
+      endpoint.hostname === "script.google.com" &&
+      endpoint.pathname.startsWith("/macros/s/")
+    );
+    const isLocalDevEndpoint = isDevMode && isLocalDevHost(endpoint.hostname);
+    if (!isGoogleAppsScript && !isLocalDevEndpoint) {
+      throw new Error("Feedback endpoint must be a deployed Google Apps Script web app URL.");
+    }
+    return endpoint.toString();
+  }
+
+  function setFeedbackControlsDisabled(disabled) {
+    ["feedback-yes", "feedback-no", "feedback-submit"].forEach((id) => {
+      const control = document.getElementById(id);
+      if (control instanceof HTMLButtonElement) {
+        control.disabled = disabled;
+      }
+    });
+  }
+
+  function renderFeedbackBox() {
+    if (!els.results || !lastExpertModeInput || !lastExpertModeOutput) {
+      console.warn("Feedback box skipped: missing results or captured request data.");
+      return;
+    }
+
+    document.getElementById("feedback-box")?.remove();
+    const feedbackBox = document.createElement("div");
+    feedbackBox.id = "feedback-box";
+    feedbackBox.className = "sg-feedback-box";
+    feedbackBox.innerHTML = `
+      <div class="sg-feedback-card">
+        <h3>Did Snow Genius help?</h3>
+        <p>Your feedback helps us tune Expert Mode for real riders.</p>
+        <div class="sg-feedback-actions">
+          <button id="feedback-yes" class="btn sg-feedback-choice" type="button">👍 Yes</button>
+          <button id="feedback-no" class="btn sg-feedback-choice" type="button" aria-expanded="false" aria-controls="feedback-details">👎 No</button>
+        </div>
+        <div id="feedback-details" class="sg-feedback-details" hidden>
+          <label class="sg-feedback-field" for="feedback-reason">
+            <span>What seems off?</span>
+            <select id="feedback-reason" class="select">
+              <option value="">Select one</option>
+              <option value="expected_different_pass">Expected a different pass</option>
+              <option value="price_seems_wrong">Price seems wrong</option>
+              <option value="resort_access_seems_wrong">Resort access seems wrong</option>
+              <option value="blackout_or_weekend_issue">Blackout/weekend issue</option>
+              <option value="other">Other</option>
+            </select>
+          </label>
+          <label class="sg-feedback-field" for="feedback-comment">
+            <span>Anything else? Optional.</span>
+            <textarea id="feedback-comment" class="input" rows="4" maxlength="2000"></textarea>
+          </label>
+          <label class="sg-feedback-field" for="feedback-email">
+            <span>Email, optional.</span>
+            <input id="feedback-email" class="input" type="email" inputmode="email" autocomplete="email" maxlength="254">
+          </label>
+          <button id="feedback-submit" class="btn primary" type="button">Submit Feedback</button>
+        </div>
+        <p id="feedback-status" class="sg-feedback-status" role="status" aria-live="polite"></p>
+      </div>
+    `;
+    els.results.appendChild(feedbackBox);
+
+    document.getElementById("feedback-yes")?.addEventListener("click", () => {
+      submitFeedback("positive");
+    });
+    document.getElementById("feedback-no")?.addEventListener("click", () => {
+      const details = document.getElementById("feedback-details");
+      const noButton = document.getElementById("feedback-no");
+      if (details) details.hidden = false;
+      noButton?.setAttribute("aria-expanded", "true");
+      document.getElementById("feedback-reason")?.focus();
+      queueHeightPost();
+    });
+    document.getElementById("feedback-submit")?.addEventListener("click", () => {
+      submitFeedback("negative");
+    });
+  }
+
+  async function submitFeedback(feedbackType) {
+    if (feedbackSubmitted || !lastExpertModeInput || !lastExpertModeOutput) return;
+
+    const status = document.getElementById("feedback-status");
+    const reasonEl = document.getElementById("feedback-reason");
+    const commentEl = document.getElementById("feedback-comment");
+    const emailEl = document.getElementById("feedback-email");
+    if (feedbackType === "negative" && emailEl instanceof HTMLInputElement && !emailEl.checkValidity()) {
+      emailEl.reportValidity();
+      return;
+    }
+
+    const payload = {
+      session_id: feedbackSessionId,
+      timestamp: new Date().toISOString(),
+      feedback_type: feedbackType,
+      reason: feedbackType === "negative" && reasonEl instanceof HTMLSelectElement ? reasonEl.value : "",
+      comment: feedbackType === "negative" && commentEl instanceof HTMLTextAreaElement ? commentEl.value.trim() : "",
+      user_email: feedbackType === "negative" && emailEl instanceof HTMLInputElement ? emailEl.value.trim() : "",
+      input_payload: lastExpertModeInput,
+      output_payload: lastExpertModeOutput,
+      recommended_passes: extractRecommendedPasses(lastExpertModeOutput),
+      solver_version: SOLVER_VERSION,
+      user_agent: navigator.userAgent,
+      page_url: window.location.href,
+    };
+
+    try {
+      const endpoint = configuredFeedbackEndpoint();
+      if (status) status.textContent = "Submitting feedback...";
+      setFeedbackControlsDisabled(true);
+      await fetch(endpoint, {
+        method: "POST",
+        mode: "no-cors",
+        credentials: "omit",
+        referrerPolicy: "no-referrer",
+        cache: "no-store",
+        headers: { "Content-Type": "text/plain;charset=utf-8" },
+        body: JSON.stringify(payload),
+      });
+      feedbackSubmitted = true;
+      if (status) status.textContent = "Thanks — feedback received.";
+    } catch (error) {
+      console.error("Feedback submit failed", error);
+      if (status) status.textContent = "Feedback could not be submitted. Please try again.";
+      setFeedbackControlsDisabled(false);
+    } finally {
+      queueHeightPost();
+    }
   }
 
   async function submitRequest(options = {}) {
@@ -2528,6 +2720,7 @@
     els.rawRequest.textContent = JSON.stringify(payload, null, 2);
 
     if (errors.length) {
+      resetFeedbackCapture();
       showError(errors);
       clearResults();
       setStatus("Validation failed.");
@@ -2539,6 +2732,8 @@
       return;
     }
 
+    resetFeedbackCapture();
+    lastExpertModeInput = payload;
     setBusy(true);
     setStatus("Submitting request...");
 
@@ -2573,11 +2768,13 @@
         throw new Error(typeof detail === "string" ? detail : JSON.stringify(detail));
       }
 
+      lastExpertModeOutput = data;
       renderResults(data, payload);
       showNotice("");
       setStatus("Results updated.");
       scrollToResults();
     } catch (error) {
+      lastExpertModeOutput = null;
       const message =
         error && typeof error === "object" && "name" in error && error.name === "AbortError"
           ? `Request timed out after ${Math.round(REQUEST_TIMEOUT_MS / 1000)}s`

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -612,6 +612,76 @@ body{
   transform:translateY(0);
 }
 
+.sg-feedback-box{
+  margin-top:24px;
+}
+
+.sg-feedback-card{
+  padding:18px;
+  border:1px solid rgba(10,132,255,.16);
+  border-radius:18px;
+  background:
+    radial-gradient(100% 120% at 100% 0%, rgba(76,201,240,.08), transparent 58%),
+    linear-gradient(180deg, rgba(255,255,255,.96), rgba(255,255,255,.88));
+  box-shadow:var(--shadow-md);
+}
+
+.sg-feedback-card h3{
+  margin:0 0 6px;
+  font-size:19px;
+  letter-spacing:-.015em;
+}
+
+.sg-feedback-card > p{
+  margin:0 0 14px;
+  color:var(--muted);
+}
+
+.sg-feedback-actions{
+  display:flex;
+  flex-wrap:wrap;
+  gap:10px;
+}
+
+.sg-feedback-choice{
+  min-width:96px;
+}
+
+.sg-feedback-details{
+  margin-top:16px;
+  padding-top:4px;
+  border-top:1px solid var(--line);
+}
+
+.sg-feedback-details[hidden]{
+  display:none;
+}
+
+.sg-feedback-field{
+  display:grid;
+  gap:6px;
+  margin-top:12px;
+  color:#496076;
+  font-size:13px;
+  font-weight:700;
+}
+
+.sg-feedback-field textarea{
+  min-height:104px;
+  resize:vertical;
+}
+
+.sg-feedback-details .btn.primary{
+  margin-top:14px;
+}
+
+.sg-feedback-status{
+  min-height:1.5em;
+  margin:12px 0 0 !important;
+  color:#365169 !important;
+  font-size:14px;
+}
+
 .notice-banner{
   margin:10px 0;
   padding:10px 12px;
@@ -1184,5 +1254,10 @@ body{
   }
   .logo{
     width:min(220px, 74vw);
+  }
+  .sg-feedback-actions,
+  .sg-feedback-actions .btn,
+  .sg-feedback-details .btn.primary{
+    width:100%;
   }
 }

--- a/google-apps-script/README.md
+++ b/google-apps-script/README.md
@@ -1,0 +1,16 @@
+# Expert Mode feedback sheet setup
+
+1. Create a Google Sheet with a tab named `feedback`.
+2. Add this header row:
+
+   `timestamp | session_id | feedback_type | reason | comment | user_email | input_payload | output_payload | recommended_passes | solver_version | user_agent | page_url`
+
+3. Open **Extensions → Apps Script**, paste `feedback.gs`, and deploy it as a web app.
+4. Set **Execute as** to the sheet owner and **Who has access** to anyone.
+5. Copy the deployed `/exec` URL into `FEEDBACK_ENDPOINT` at the top of `assets/script.js`.
+
+The endpoint is intentionally public and contains no secret. The script validates the known feedback fields, limits stored text, and neutralizes spreadsheet-formula prefixes in user-controlled values.
+
+For local QA only, dev mode can override the destination without editing the production constant:
+
+`?devmode&feedbackEndpoint=http://127.0.0.1:8001/feedback`

--- a/google-apps-script/feedback.gs
+++ b/google-apps-script/feedback.gs
@@ -1,0 +1,82 @@
+const SHEET_NAME = "feedback";
+const ALLOWED_FEEDBACK_TYPES = new Set(["positive", "negative"]);
+const ALLOWED_REASONS = new Set([
+  "",
+  "expected_different_pass",
+  "price_seems_wrong",
+  "resort_access_seems_wrong",
+  "blackout_or_weekend_issue",
+  "other",
+]);
+
+function doPost(e) {
+  try {
+    const rawBody = e && e.postData ? e.postData.contents || "{}" : "{}";
+    if (rawBody.length > 250000) {
+      throw new Error("Feedback payload is too large");
+    }
+
+    const body = JSON.parse(rawBody);
+    if (!ALLOWED_FEEDBACK_TYPES.has(body.feedback_type)) {
+      throw new Error("Invalid feedback_type");
+    }
+    if (!ALLOWED_REASONS.has(body.reason || "")) {
+      throw new Error("Invalid reason");
+    }
+
+    const sheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName(SHEET_NAME);
+    if (!sheet) {
+      throw new Error("Missing sheet tab: " + SHEET_NAME);
+    }
+
+    const row = [
+      validTimestamp(body.timestamp),
+      sanitize(body.session_id, 100),
+      sanitize(body.feedback_type, 20),
+      sanitize(body.reason, 80),
+      sanitize(body.comment, 2000),
+      sanitize(body.user_email, 254),
+      safeJson(body.input_payload || {}, 45000),
+      safeJson(body.output_payload || {}, 45000),
+      safeJson(body.recommended_passes || [], 45000),
+      sanitize(body.solver_version, 100),
+      sanitize(body.user_agent, 1000),
+      sanitize(body.page_url, 2000),
+    ];
+    sheet.appendRow(row);
+    return jsonResponse({ ok: true });
+  } catch (err) {
+    return jsonResponse({ ok: false, error: String(err) });
+  }
+}
+
+function doGet() {
+  return jsonResponse({
+    ok: true,
+    message: "Snow Genius feedback endpoint is live",
+  });
+}
+
+function validTimestamp(value) {
+  const timestamp = new Date(value);
+  return isNaN(timestamp.getTime()) ? new Date() : timestamp;
+}
+
+function sanitize(value, maxLength) {
+  if (value === null || value === undefined) return "";
+  let text = String(value).slice(0, maxLength || 5000);
+  if (/^[=+\-@]/.test(text)) {
+    text = "'" + text;
+  }
+  return text;
+}
+
+function safeJson(value, maxLength) {
+  return sanitize(JSON.stringify(value), maxLength);
+}
+
+function jsonResponse(obj) {
+  return ContentService
+    .createTextOutput(JSON.stringify(obj))
+    .setMimeType(ContentService.MimeType.JSON);
+}

--- a/index.html
+++ b/index.html
@@ -6,12 +6,12 @@
   <meta name="referrer" content="no-referrer" />
   <meta
     http-equiv="Content-Security-Policy"
-    content="default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data:; connect-src 'self' https://pass-picker-expert-mode-multi.onrender.com http://127.0.0.1:* http://localhost:*; object-src 'none'; base-uri 'none'; form-action 'self'"
+    content="default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data:; connect-src 'self' https://pass-picker-expert-mode-multi.onrender.com https://script.google.com https://script.googleusercontent.com http://127.0.0.1:* http://localhost:*; object-src 'none'; base-uri 'none'; form-action 'self'"
   />
   <title>Snow Genius — Expert Mode</title>
   <link rel="preload" href="resorts.json" as="fetch" crossorigin="anonymous">
   <script src="assets/bootstrap.js?v=20260226a"></script>
-  <link rel="stylesheet" href="assets/styles.css?v=20260620a" />
+  <link rel="stylesheet" href="assets/styles.css?v=20260624a" />
 </head>
 <body>
   <header class="hero hero-compact">
@@ -131,6 +131,6 @@
 
   <footer class="footer">© Snow Genius</footer>
 
-  <script src="assets/script.js?v=20260620a" defer></script>
+  <script src="assets/script.js?v=20260624a" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add a post-results positive/negative feedback card
- capture the exact Expert Mode request, response, recommendation, and anonymous session metadata
- add a Google Apps Script receiver with validation, size limits, and spreadsheet formula-injection protection
- allow Google Apps Script in the page CSP and document sheet deployment

## Validation
- `node --check assets/script.js`
- `git diff --check`
- Apps Script row and sanitization harness
- local browser QA for positive feedback, negative reason/comment with blank optional email, duplicate prevention, missing-endpoint recovery, and full payload capture

## Deployment note
The Google Apps Script `/exec` URL still needs to replace the placeholder `FEEDBACK_ENDPOINT` after the sheet web app is deployed.