### PR TITLE
Enable outbound pass click tracking

### DIFF
--- a/assets/analytics.js
+++ b/assets/analytics.js
@@ -1,0 +1,9 @@
+window.dataLayer = window.dataLayer || [];
+
+function gtag() {
+  window.dataLayer.push(arguments);
+}
+
+window.gtag = gtag;
+window.gtag("js", new Date());
+window.gtag("config", "G-VXZQRHD1WH");

--- a/assets/script.js
+++ b/assets/script.js
@@ -1887,6 +1887,8 @@
       link.target = "_blank";
       link.rel = "noopener noreferrer";
       link.className = "pass-name-link";
+      link.dataset.passFamily = getPassFamily(passItem);
+      link.dataset.passName = String(passName);
       link.textContent = passName;
       label.appendChild(link);
     } else {
@@ -2801,6 +2803,22 @@
   }
 
   function bindEvents() {
+    document.addEventListener("click", (event) => {
+      const target = event.target;
+      const link = target instanceof Element ? target.closest(".pass-name-link") : null;
+      if (!(link instanceof HTMLAnchorElement) || typeof window.gtag !== "function") {
+        return;
+      }
+
+      window.gtag("event", "pass_family_click", {
+        pass_family: link.dataset.passFamily || "",
+        pass_name: link.dataset.passName || link.textContent.trim(),
+        outbound_url: link.href,
+        page_path: window.location.pathname,
+        link_text: link.textContent.trim(),
+      });
+    });
+
     els.addRider?.addEventListener("click", () => {
       const count = els.ridersWrap.querySelectorAll(".rider-row").length;
       if (count >= MAX_RIDERS) {

--- a/index.html
+++ b/index.html
@@ -6,10 +6,12 @@
   <meta name="referrer" content="no-referrer" />
   <meta
     http-equiv="Content-Security-Policy"
-    content="default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data:; connect-src 'self' https://pass-picker-expert-mode-multi.onrender.com https://script.google.com https://script.googleusercontent.com http://127.0.0.1:* http://localhost:*; object-src 'none'; base-uri 'none'; form-action 'self'"
+    content="default-src 'self'; script-src 'self' https://www.googletagmanager.com; style-src 'self'; img-src 'self' data: https://www.googletagmanager.com https://www.google-analytics.com; connect-src 'self' https://www.googletagmanager.com https://*.google-analytics.com https://analytics.google.com https://pass-picker-expert-mode-multi.onrender.com https://script.google.com https://script.googleusercontent.com http://127.0.0.1:* http://localhost:*; object-src 'none'; base-uri 'none'; form-action 'self'"
   />
   <title>Snow Genius — Expert Mode</title>
   <link rel="preload" href="resorts.json" as="fetch" crossorigin="anonymous">
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-VXZQRHD1WH"></script>
+  <script src="assets/analytics.js?v=20260701a"></script>
   <script src="assets/bootstrap.js?v=20260226a"></script>
   <link rel="stylesheet" href="assets/styles.css?v=20260624a" />
 </head>


### PR DESCRIPTION
## Summary
- install Google tag G-VXZQRHD1WH with CSP allowances
- add pass family and pass name metadata to outbound recommendation links
- emit one delegated pass_family_click event without delaying navigation

## Validation
- node --check assets/analytics.js
- node --check assets/script.js
- git diff --check
- local browser recommendation flow and rendered link metadata
- production /catalog_status confirms outbound tracking enabled
- production /score_pass returns signed tracking_url values